### PR TITLE
Fixed a garbled sentence

### DIFF
--- a/guides/github-pages/index.html
+++ b/guides/github-pages/index.html
@@ -194,7 +194,7 @@ ul.posts li &lbrace;
 		&lt;/footer&gt;
 	&lt;/body&gt;
 &lt;/html&gt;</code></pre>
-<p>Visit <a href="#">http://username.github.io</a> to see your styled website. It should look at like <a href="http://hankquinlan.github.io">http://hankquinlan.github.io</a>.</p>
+<p>Visit <a href="#">http://username.github.io</a> to see your styled website. It should look like the page at <a href="http://hankquinlan.github.io">http://hankquinlan.github.io</a>.</p>
 
 <h2>Using Jekyll with GitHub Pages</h2>
 <p>Like GitHub Pages, Jekyll is self-aware, so if you add folders and files following specific naming conventions, when you commit to GitHub, Jekyll will magically build your website.</p>


### PR DESCRIPTION
I found another small error. I think you might have missed a word or two.

I think I changed it to what you meant.

Original
: It should look at like http://hankquinlan.github.io.
Changed to
: It should look like the page at http://hankquinlan.github.io.
