### PR TITLE
Update 'http' to 'https' in the request to code.jquery.com

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,5 +1,5 @@
 <!-- javascript at the end of the doc so page loads faster -->
-<script src="http://code.jquery.com/jquery.js"></script>
+<script src="https://code.jquery.com/jquery.js"></script>
 <script src="/js/bootstrap.min.js"></script>
 <script src="/js/library.js"></script>
 <script src="https://google-code-prettify.googlecode.com/svn/loader/run_prettify.js"></script>


### PR DESCRIPTION
I would like to suggest using 'https' instead of 'http' in the request to jquery, because it is the only reason why chrome and firefox display 'unsafe connection' in the address line.